### PR TITLE
Install Dependencies on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ MAINTAINER Aleksandr Popov  <mogadanez@gmail.com>
 # Create sqsd directory
 WORKDIR /
 RUN mkdir /sqsd
+WORKDIR /sqsd
 
 # Copy sqsd source including
 COPY ./ /sqsd
 
+# Install dependencies
+RUN npm install
+
 # Run sqsd
-WORKDIR /sqsd
 CMD ["node", "run-cli.js"]
 


### PR DESCRIPTION
Hello,
this adds a `npm install` during `docker build`.
This way this step is not needed before building the container.