### PR TITLE
Allow SQSD to pass on the AWSTraceHeader

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,9 @@ class SQSProcessor {
         if (sqsMessage.Attributes && sqsMessage.Attributes.SenderId)
             headers['X-Aws-Sqsd-Sender-Id'] = sqsMessage.Attributes.SenderId;
 
+        if (sqsMessage.Attributes && sqsMessage.Attributes.AWSTraceHeader)
+            headers['X-Amzn-Trace-Id'] = sqsMessage.Attributes.AWSTraceHeader;
+
         for(let name in sqsMessage.MessageAttributes) {
             const value = sqsMessage.MessageAttributes[name];
             headers['X-Aws-Sqsd-Attr-'+name] = value.StringValue;

--- a/lib/index.js
+++ b/lib/index.js
@@ -167,6 +167,7 @@ class SQSProcessor {
             WaitTimeSeconds: this.options.waitTime,
             AttributeNames: ["All"],
             MessageAttributeNames: ["All"],
+            VisibilityTimeout: "1210",
             QueueUrl: this.options.queueUrl
         }).promise();
 


### PR DESCRIPTION
Allows AWS Xray traces to 'join up' when you have a web and worker tier in elastic beanstalk communicating via SQS.

This diverges from the AWS implementation of SQSD where this doesn't seem to work. Useful for what I'm doing, not sure if something you'd want in your implementation though.

